### PR TITLE
feat: add chinese locale option to the frontend

### DIFF
--- a/apps/frontend/src/components/language-switcher.tsx
+++ b/apps/frontend/src/components/language-switcher.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import { msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 import { useLingui } from '@lingui/react'
 import { usePathname, useRouter } from 'next/navigation'
 import {
@@ -13,9 +14,19 @@ import {
 import { GlobeIcon } from 'lucide-react'
 import { Button } from '@repo/ui/components/button'
 
-type LOCALES = 'ar' | 'en' | 'tr' | 'pseudo'
+import type { Locale } from '@/utils/locales'
 
-const languages = {
+const supportedLocales = [
+  'en',
+  'es',
+  'it',
+  'pt',
+  'zh',
+] as const satisfies readonly Locale[]
+
+type SupportedLocale = (typeof supportedLocales)[number]
+
+const languages: Record<SupportedLocale, MessageDescriptor> = {
   en: msg`English`,
   // ar: msg`Arabic`,
   // de: msg`German`,
@@ -27,8 +38,8 @@ const languages = {
   pt: msg`Portuguese`,
   // ru: msg`Russian`,
   // tr: msg`Turkish`,
-  // zh: msg`Chinese`,
-} as const
+  zh: msg`Chinese`,
+}
 
 export function LanguageSwitcher() {
   const router = useRouter()
@@ -40,11 +51,9 @@ export function LanguageSwitcher() {
   //   languages['pseudo'] = t`Pseudo`
   // }
 
-  function handleChange(newLocale: string) {
-    const locale = newLocale as LOCALES
-
+  function handleChange(newLocale: SupportedLocale) {
     const pathNameWithoutLocale = pathname?.split('/')?.slice(2) ?? []
-    const newPath = `/${locale}/${pathNameWithoutLocale.join('/')}`
+    const newPath = `/${newLocale}/${pathNameWithoutLocale.join('/')}`
 
     router.push(newPath)
   }
@@ -57,13 +66,11 @@ export function LanguageSwitcher() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">
-        {Object.keys(languages).map((locale) => {
-          return (
-            <DropdownMenuItem key={locale} onClick={() => handleChange(locale)}>
-              {i18n._(languages[locale as keyof typeof languages])}
-            </DropdownMenuItem>
-          )
-        })}
+        {supportedLocales.map((locale) => (
+          <DropdownMenuItem key={locale} onClick={() => handleChange(locale)}>
+            {i18n._(languages[locale])}
+          </DropdownMenuItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/frontend/src/locales/ar/messages.po
+++ b/apps/frontend/src/locales/ar/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "حدث خطأ ما"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "الصينية"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "الإسبانية"
 

--- a/apps/frontend/src/locales/bn/messages.po
+++ b/apps/frontend/src/locales/bn/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "কিছু ভুল হয়েছে"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "চীনা"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "স্প্যানিশ"
 

--- a/apps/frontend/src/locales/de/messages.po
+++ b/apps/frontend/src/locales/de/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Chinesisch"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Spanisch"
 

--- a/apps/frontend/src/locales/el/messages.po
+++ b/apps/frontend/src/locales/el/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Κάτι πήγε στραβά"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Κινέζικα"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Ισπανικά"
 

--- a/apps/frontend/src/locales/en/messages.po
+++ b/apps/frontend/src/locales/en/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Something went wrong"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Chinese"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Spanish"
 

--- a/apps/frontend/src/locales/es/messages.po
+++ b/apps/frontend/src/locales/es/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Algo salió mal"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Chino"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Español"
 

--- a/apps/frontend/src/locales/fa/messages.po
+++ b/apps/frontend/src/locales/fa/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "اشتباهی رخ داد"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "چینی"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "اسپانیایی"
 

--- a/apps/frontend/src/locales/fr/messages.po
+++ b/apps/frontend/src/locales/fr/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Un problème est survenu"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Chinois"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Espagnol"
 

--- a/apps/frontend/src/locales/hi/messages.po
+++ b/apps/frontend/src/locales/hi/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "कुछ गलत हो गया"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "चीनी"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "स्पेनिश"
 

--- a/apps/frontend/src/locales/id/messages.po
+++ b/apps/frontend/src/locales/id/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Ada yang salah"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Mandarin"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Spanyol"
 

--- a/apps/frontend/src/locales/it/messages.po
+++ b/apps/frontend/src/locales/it/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Qualcosa è andato storto"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Cinese"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Spagnolo"
 

--- a/apps/frontend/src/locales/ja/messages.po
+++ b/apps/frontend/src/locales/ja/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "問題が発生しました"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "中国語"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "スペイン語"
 

--- a/apps/frontend/src/locales/ko/messages.po
+++ b/apps/frontend/src/locales/ko/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "중국어"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "스페인어"
 

--- a/apps/frontend/src/locales/pseudo/messages.po
+++ b/apps/frontend/src/locales/pseudo/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Ṡǿṁḗŧħīƞɠ ẇḗƞŧ ẇřǿƞɠ"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Ċħīƞḗşḗ"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Ṡƥȧƞīşħ"
 

--- a/apps/frontend/src/locales/pt/messages.po
+++ b/apps/frontend/src/locales/pt/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Algo deu errado"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Chinês"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Espanhol"
 

--- a/apps/frontend/src/locales/ru/messages.po
+++ b/apps/frontend/src/locales/ru/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Что-то пошло не так"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Китайский"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Испанский"
 

--- a/apps/frontend/src/locales/th/messages.po
+++ b/apps/frontend/src/locales/th/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "มีบางอย่างผิดพลาด"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "ภาษาจีน"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "ภาษาสเปน"
 

--- a/apps/frontend/src/locales/tr/messages.po
+++ b/apps/frontend/src/locales/tr/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Bir şeyler ters gitti"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Çince"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "İspanyolca"
 

--- a/apps/frontend/src/locales/vi/messages.po
+++ b/apps/frontend/src/locales/vi/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "Đã xảy ra lỗi"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "Tiếng Trung"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Tiếng Tây Ban Nha"
 

--- a/apps/frontend/src/locales/zh/messages.po
+++ b/apps/frontend/src/locales/zh/messages.po
@@ -281,6 +281,10 @@ msgid "Something went wrong"
 msgstr "出错了"
 
 #: src/components/language-switcher.tsx
+msgid "Chinese"
+msgstr "中文"
+
+#: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "西班牙语"
 

--- a/apps/frontend/tests/components/language-switcher.test.tsx
+++ b/apps/frontend/tests/components/language-switcher.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LanguageSwitcher } from '@/components/language-switcher'
+
+const pushMock = vi.fn()
+
+vi.mock('@lingui/core/macro', () => ({
+  msg: (message: TemplateStringsArray) => message[0],
+}))
+
+vi.mock('@lingui/react', () => ({
+  useLingui: () => ({
+    i18n: {
+      _: (message: string) => message,
+    },
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  usePathname: () => '/en',
+}))
+
+vi.mock('@repo/ui/components/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode
+    onClick: () => void
+  }) => (
+    <div onClick={onClick} role="button">
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('@repo/ui/components/button', () => ({
+  Button: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}))
+
+describe('LanguageSwitcher', () => {
+  it('includes the Chinese language option', () => {
+    render(<LanguageSwitcher />)
+
+    expect(screen.getByText('Chinese')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add the Chinese locale to the language switcher and type its supported locales
- translate the new Chinese label across every message catalog
- add a unit test to ensure the Chinese option renders in the switcher

## Testing
- pnpm --filter @repo/frontend test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fbd17ab774832e96043cac4a9b024b