### PR TITLE
fix: stabilize language switcher locales

### DIFF
--- a/apps/frontend/src/components/language-switcher.test.tsx
+++ b/apps/frontend/src/components/language-switcher.test.tsx
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom/vitest'
+
+import { setupI18n, type MessageDescriptor } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pushMock = vi.fn()
+
+vi.mock('@lingui/core/macro', () => ({
+  msg: (message: TemplateStringsArray | string): MessageDescriptor => {
+    if (typeof message === 'string') {
+      return { id: message, message }
+    }
+    return { id: message[0], message: message[0] }
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  usePathname: () => '/en',
+}))
+
+describe('LanguageSwitcher', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+  })
+
+  it('lists French as an available language', async () => {
+    const { LanguageSwitcher } = await import('./language-switcher')
+    const i18n = setupI18n({
+      locale: 'en',
+      messages: {
+        en: {
+          English: 'English',
+          Spanish: 'Spanish',
+          French: 'French',
+          Italian: 'Italian',
+          Portuguese: 'Portuguese',
+        },
+      },
+    })
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <LanguageSwitcher />
+      </I18nProvider>,
+    )
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(await screen.findByText('French')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/language-switcher.tsx
+++ b/apps/frontend/src/components/language-switcher.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import { msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 import { useLingui } from '@lingui/react'
 import { usePathname, useRouter } from 'next/navigation'
 import {
@@ -12,23 +13,21 @@ import {
 } from '@repo/ui/components/dropdown-menu'
 import { GlobeIcon } from 'lucide-react'
 import { Button } from '@repo/ui/components/button'
+import { isIncludedIn } from 'remeda'
 
-type LOCALES = 'ar' | 'en' | 'tr' | 'pseudo'
+const supportedLocales = ['en', 'es', 'fr', 'it', 'pt'] as const
 
-const languages = {
+type SupportedLocale = (typeof supportedLocales)[number]
+
+const languageLabels = {
   en: msg`English`,
-  // ar: msg`Arabic`,
-  // de: msg`German`,
   es: msg`Spanish`,
-  // fr: msg`French`,
-  // id: msg`Indonesian`,
+  fr: msg`French`,
   it: msg`Italian`,
-  // ja: msg`Japanese`,
   pt: msg`Portuguese`,
-  // ru: msg`Russian`,
-  // tr: msg`Turkish`,
-  // zh: msg`Chinese`,
-} as const
+} satisfies Record<SupportedLocale, MessageDescriptor>
+
+const isSupportedLocale = isIncludedIn(supportedLocales)
 
 export function LanguageSwitcher() {
   const router = useRouter()
@@ -41,10 +40,12 @@ export function LanguageSwitcher() {
   // }
 
   function handleChange(newLocale: string) {
-    const locale = newLocale as LOCALES
+    if (!isSupportedLocale(newLocale)) {
+      return
+    }
 
     const pathNameWithoutLocale = pathname?.split('/')?.slice(2) ?? []
-    const newPath = `/${locale}/${pathNameWithoutLocale.join('/')}`
+    const newPath = `/${newLocale}/${pathNameWithoutLocale.join('/')}`
 
     router.push(newPath)
   }
@@ -57,10 +58,10 @@ export function LanguageSwitcher() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">
-        {Object.keys(languages).map((locale) => {
+        {supportedLocales.map((locale) => {
           return (
             <DropdownMenuItem key={locale} onClick={() => handleChange(locale)}>
-              {i18n._(languages[locale as keyof typeof languages])}
+              {i18n._(languageLabels[locale])}
             </DropdownMenuItem>
           )
         })}

--- a/apps/frontend/src/locales/ar/messages.po
+++ b/apps/frontend/src/locales/ar/messages.po
@@ -284,6 +284,10 @@ msgstr "حدث خطأ ما"
 msgid "Spanish"
 msgstr "الإسبانية"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "الفرنسية"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "تبديل الشبكة"

--- a/apps/frontend/src/locales/bn/messages.po
+++ b/apps/frontend/src/locales/bn/messages.po
@@ -284,6 +284,10 @@ msgstr "কিছু ভুল হয়েছে"
 msgid "Spanish"
 msgstr "স্প্যানিশ"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "ফরাসি"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "নেটওয়ার্ক পরিবর্তন করুন"

--- a/apps/frontend/src/locales/de/messages.po
+++ b/apps/frontend/src/locales/de/messages.po
@@ -284,6 +284,10 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Spanish"
 msgstr "Spanisch"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Französisch"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Netzwerk wechseln"

--- a/apps/frontend/src/locales/el/messages.po
+++ b/apps/frontend/src/locales/el/messages.po
@@ -284,6 +284,10 @@ msgstr "Κάτι πήγε στραβά"
 msgid "Spanish"
 msgstr "Ισπανικά"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Γαλλικά"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Αλλαγή Δικτύου"

--- a/apps/frontend/src/locales/en/messages.po
+++ b/apps/frontend/src/locales/en/messages.po
@@ -284,6 +284,10 @@ msgstr "Something went wrong"
 msgid "Spanish"
 msgstr "Spanish"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "French"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Switch Network"

--- a/apps/frontend/src/locales/es/messages.po
+++ b/apps/frontend/src/locales/es/messages.po
@@ -284,6 +284,10 @@ msgstr "Algo salió mal"
 msgid "Spanish"
 msgstr "Español"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Francés"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Cambiar red"

--- a/apps/frontend/src/locales/fa/messages.po
+++ b/apps/frontend/src/locales/fa/messages.po
@@ -284,6 +284,10 @@ msgstr "اشتباهی رخ داد"
 msgid "Spanish"
 msgstr "اسپانیایی"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "فرانسوی"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "تغییر شبکه"

--- a/apps/frontend/src/locales/fr/messages.po
+++ b/apps/frontend/src/locales/fr/messages.po
@@ -170,7 +170,7 @@ msgstr "Masquer les détails"
 
 #: src/components/auction-seed-dialog.tsx
 msgid "Insufficient ETH balance. Price is {priceLabel}, your balance is {balanceLabel}."
-msgstr ""
+msgstr "Solde ETH insuffisant. Le prix est {priceLabel}, votre solde est {balanceLabel}."
 
 #: src/components/language-switcher.tsx
 msgid "Italian"
@@ -283,6 +283,10 @@ msgstr "Un problème est survenu"
 #: src/components/language-switcher.tsx
 msgid "Spanish"
 msgstr "Espagnol"
+
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Français"
 
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"

--- a/apps/frontend/src/locales/hi/messages.po
+++ b/apps/frontend/src/locales/hi/messages.po
@@ -284,6 +284,10 @@ msgstr "कुछ गलत हो गया"
 msgid "Spanish"
 msgstr "स्पेनिश"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "फ्रेंच"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "नेटवर्क बदलें"

--- a/apps/frontend/src/locales/id/messages.po
+++ b/apps/frontend/src/locales/id/messages.po
@@ -284,6 +284,10 @@ msgstr "Ada yang salah"
 msgid "Spanish"
 msgstr "Spanyol"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Prancis"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Ganti Jaringan"

--- a/apps/frontend/src/locales/it/messages.po
+++ b/apps/frontend/src/locales/it/messages.po
@@ -284,6 +284,10 @@ msgstr "Qualcosa è andato storto"
 msgid "Spanish"
 msgstr "Spagnolo"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Francese"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Cambia rete"

--- a/apps/frontend/src/locales/ja/messages.po
+++ b/apps/frontend/src/locales/ja/messages.po
@@ -284,6 +284,10 @@ msgstr "問題が発生しました"
 msgid "Spanish"
 msgstr "スペイン語"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "フランス語"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "ネットワークを切り替え"

--- a/apps/frontend/src/locales/ko/messages.po
+++ b/apps/frontend/src/locales/ko/messages.po
@@ -284,6 +284,10 @@ msgstr "문제가 발생했습니다"
 msgid "Spanish"
 msgstr "스페인어"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "프랑스어"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "네트워크 전환"

--- a/apps/frontend/src/locales/pseudo/messages.po
+++ b/apps/frontend/src/locales/pseudo/messages.po
@@ -284,6 +284,10 @@ msgstr "Ṡǿṁḗŧħīƞɠ ẇḗƞŧ ẇřǿƞɠ"
 msgid "Spanish"
 msgstr "Ṡƥȧƞīşħ"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Ƒřḗƞƈħ"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Şẇīŧƈħ Ƞḗŧẇǿřķ"

--- a/apps/frontend/src/locales/pt/messages.po
+++ b/apps/frontend/src/locales/pt/messages.po
@@ -284,6 +284,10 @@ msgstr "Algo deu errado"
 msgid "Spanish"
 msgstr "Espanhol"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Francês"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Trocar Rede"

--- a/apps/frontend/src/locales/ru/messages.po
+++ b/apps/frontend/src/locales/ru/messages.po
@@ -284,6 +284,10 @@ msgstr "Что-то пошло не так"
 msgid "Spanish"
 msgstr "Испанский"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Французский"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Сменить сеть"

--- a/apps/frontend/src/locales/th/messages.po
+++ b/apps/frontend/src/locales/th/messages.po
@@ -284,6 +284,10 @@ msgstr "มีบางอย่างผิดพลาด"
 msgid "Spanish"
 msgstr "ภาษาสเปน"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "ภาษาฝรั่งเศส"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "สลับเครือข่าย"

--- a/apps/frontend/src/locales/tr/messages.po
+++ b/apps/frontend/src/locales/tr/messages.po
@@ -284,6 +284,10 @@ msgstr "Bir şeyler ters gitti"
 msgid "Spanish"
 msgstr "İspanyolca"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Fransızca"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Ağı Değiştir"

--- a/apps/frontend/src/locales/vi/messages.po
+++ b/apps/frontend/src/locales/vi/messages.po
@@ -284,6 +284,10 @@ msgstr "Đã xảy ra lỗi"
 msgid "Spanish"
 msgstr "Tiếng Tây Ban Nha"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "Tiếng Pháp"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "Chuyển mạng"

--- a/apps/frontend/src/locales/zh/messages.po
+++ b/apps/frontend/src/locales/zh/messages.po
@@ -284,6 +284,10 @@ msgstr "出错了"
 msgid "Spanish"
 msgstr "西班牙语"
 
+#: src/components/language-switcher.tsx
+msgid "French"
+msgstr "法语"
+
 #: src/components/auction-seed-dialog.tsx
 msgid "Switch Network"
 msgstr "切换网络"


### PR DESCRIPTION
## Summary
- define the language switcher locales explicitly and type the label map against them

## Testing
- pnpm --filter frontend test
- pnpm --filter frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68fbd0120688832ea107864443703a22