### PR TITLE
feat(frontend): enable French locale selection

### DIFF
--- a/apps/frontend/src/components/language-switcher.tsx
+++ b/apps/frontend/src/components/language-switcher.tsx
@@ -19,6 +19,7 @@ import type { Locale } from '@/utils/locales'
 const supportedLocales = [
   'en',
   'es',
+  'fr',
   'it',
   'pt',
   'zh',
@@ -31,7 +32,7 @@ const languages: Record<SupportedLocale, MessageDescriptor> = {
   // ar: msg`Arabic`,
   // de: msg`German`,
   es: msg`Spanish`,
-  // fr: msg`French`,
+  fr: msg`French`,
   // id: msg`Indonesian`,
   it: msg`Italian`,
   // ja: msg`Japanese`,

--- a/apps/frontend/tests/components/language-switcher.test.tsx
+++ b/apps/frontend/tests/components/language-switcher.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LanguageSwitcher } from '@/components/language-switcher'
 
@@ -54,9 +54,24 @@ vi.mock('@repo/ui/components/button', () => ({
 }))
 
 describe('LanguageSwitcher', () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+  })
+
   it('includes the Chinese language option', () => {
     render(<LanguageSwitcher />)
 
     expect(screen.getByText('Chinese')).toBeInTheDocument()
+  })
+
+  it('includes the French language option and navigates to the locale route', () => {
+    render(<LanguageSwitcher />)
+
+    const frenchOption = screen.getAllByText('French')[0]
+    expect(frenchOption).toBeInTheDocument()
+
+    frenchOption.click()
+
+    expect(pushMock).toHaveBeenCalledWith('/fr/')
   })
 })


### PR DESCRIPTION
## Summary
- add the French locale to the language switcher so it mirrors existing Spanish support
- add coverage ensuring the switcher renders the French option and routes to the locale path

## Testing
- pnpm --filter @repo/frontend test
- pnpm --filter @repo/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68fbe4f1d294832e89bdf0f70718ed1e